### PR TITLE
Update 10-vbr.conf

### DIFF
--- a/etc/rsyslog.d/10-vbr.conf
+++ b/etc/rsyslog.d/10-vbr.conf
@@ -13,13 +13,13 @@
 
    # Use the template for logs from honeypots
    # Replace SYSLOG_SERVER with the IP address or host name of your remote log server.
-   if $programname startswith 'vbr_honeypot' or
-      $programname startswith 'vhr_honeypot' or
-      $programname startswith 'vwr_honeypot' or
-      $programname startswith 'vbem_honeypot' or
-      $programname startswith 'rdp_honeypot' or
-      $programname startswith 'ssh_honeypot' or
-      $programname startswith 'netbios_honeypot' then {
-      @@SYSLOG_SERVER:1514;VeeamHoneypotFormat
-   }
-
+   if ($msg contains "vbr_honeypot" or
+    $msg contains "vhr_honeypot" or
+    $msg contains "vwr_honeypot" or
+    $msg contains "vbem_honeypot" or
+    $msg contains "rdp_honeypot" or
+    $msg contains "ssh_honeypot" or
+    $msg contains "netbios_honeypot") then {
+    *.* @@SYSLOG_SERVER:514;VeeamHoneypotFormat
+    stop
+    }


### PR DESCRIPTION
The Source of the logs in system messages is coming from python3. The rsyslog variable $programname is to match the application that created the log, or the Source; so the honeypots were not being matched. Instead, the honeypots are contained within the message, so I Replaced `$programname startswith` with `$msg contains` so the honeypots are matched. This might be able to be condensed further with matching `*_honeypot`, but I didn't want to go too far and match too much.

Additionally, added `*.*` to the then statement to tell rsyslog to forward the matched message with its original facility/severity to the remote server.

And a stop to not log the message anywhere else to avoid duplicates.

As stated in VeeamHub#3 this fixes the logs being forwarded to a remote EventLog Analyzer server.